### PR TITLE
Added opt-out capabilities. Now commiters can opt-out by adding **NOPAY*...

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ BitHub
 
 BitHub is a service that will automatically pay a percentage of Bitcoin funds for every submission to a GitHub repository.
 
+Opting Out
+----------
+
+If your conscience is troubled at recieving payment for changing a few lines of documentation, simply add "FREEBIE" to your commit message, and you will not recieve BTC for that commit.
+
+
 Building
 -------------
 

--- a/src/main/java/org/whispersystems/bithub/controllers/GithubController.java
+++ b/src/main/java/org/whispersystems/bithub/controllers/GithubController.java
@@ -146,8 +146,9 @@ public class GithubController {
       logger.info(commit.getUrl());
       if (!emails.contains(commit.getAuthor().getEmail())) {
         logger.info("Unique author: "+ commit.getAuthor().getEmail());
-        if (commit.getMessage() == null || !commit.getMessage().startsWith("Merge")) {
-          logger.info("Not a merge commit...");
+        if (commit.getMessage() == null || (!commit.getMessage().startsWith("Merge") && !commit.getMessage().contains("FREEBIE"))) {
+          logger.info("Not a merge commit or freebie...");
+
           emails.add(commit.getAuthor().getEmail());
           commits.add(commit);
         }


### PR DESCRIPTION
...\* to their commit messages (and yes, that NOPAY was intentional. This commit comes gratis).

I also updated the README to reflect this new feature.
