### PR TITLE
Added option for viewing past transactions in BTC

### DIFF
--- a/src/main/java/org/whispersystems/bithub/controllers/StatusController.java
+++ b/src/main/java/org/whispersystems/bithub/controllers/StatusController.java
@@ -117,6 +117,7 @@ public class StatusController {
     return new RecentTransactionsView(recentTransactions, exchangeRate);
   }
 
+
   public void initializeUpdates(final CoinbaseClient coinbaseClient) {
     executor.scheduleAtFixedRate(new Runnable() {
       @Override

--- a/src/main/java/org/whispersystems/bithub/views/RecentTransactionsView.java
+++ b/src/main/java/org/whispersystems/bithub/views/RecentTransactionsView.java
@@ -39,7 +39,7 @@ public class RecentTransactionsView extends View {
 
   public RecentTransactionsView(List<Transaction> recentTransactions, BigDecimal exchangeRate) {
     super("recent_transactions.mustache");
-
+    
     for (Transaction transaction : recentTransactions) {
       try {
         if (isSentTransaction(transaction)) {

--- a/src/main/java/org/whispersystems/bithub/views/TransactionView.java
+++ b/src/main/java/org/whispersystems/bithub/views/TransactionView.java
@@ -38,15 +38,17 @@ public class TransactionView {
 
   private final String destination;
   private final String amount;
+  private final String amountInBTC;
   private final String commitUrl;
   private final String commitSha;
   private final String timestamp;
 
-  public TransactionView(BigDecimal exchangeRate, String amount,
+  public TransactionView(BigDecimal exchangeRate, String transactionAmount,
                          String timestamp, String message)
       throws ParseException
   {
-    this.amount      = getAmountInDollars(exchangeRate, amount);
+    this.amount      = getAmountInDollars(exchangeRate, transactionAmount);
+    this.amountInBTC   = getAmountInBTC(transactionAmount);
     this.destination = parseDestinationFromMessage(message);
     this.timestamp   = parseTimestamp(timestamp);
     this.commitUrl   = parseUrlFromMessage(message);
@@ -57,6 +59,12 @@ public class TransactionView {
     return new BigDecimal(amount).abs()
                                  .multiply(exchangeRate)
                                  .setScale(2, RoundingMode.CEILING)
+                                 .toPlainString();
+  }
+
+  private String getAmountInBTC(String amount) {
+    return new BigDecimal(amount).abs()
+                                 .setScale(4, RoundingMode.CEILING)
                                  .toPlainString();
   }
 
@@ -111,6 +119,10 @@ public class TransactionView {
 
   public String getAmount() {
     return amount;
+  }
+
+  public String getAmountInBTC() {
+    return amountInBTC;
   }
 
   public String getCommitUrl() {

--- a/src/main/resources/org/whispersystems/bithub/views/recent_transactions.mustache
+++ b/src/main/resources/org/whispersystems/bithub/views/recent_transactions.mustache
@@ -44,7 +44,7 @@
 
 <ul>
     {{#transactions}}
-    <li>Sent ${{amount}} USD to <a href="https://github.com/{{destination}}" target="_blank">{{destination}}</a> for <a href="{{commitUrl}}" target="_blank"><sha>{{commitSha}}</sha></a> {{timestamp}}.</li>
+    <li>Sent ${{amount}} USD ({{amountInBTC}} BTC) to <a href="https://github.com/{{destination}}" target="_blank">{{destination}}</a> for <a href="{{commitUrl}}" target="_blank"><sha>{{commitSha}}</sha></a> {{timestamp}}.</li>
     {{/transactions}}
 </ul>
 

--- a/src/test/java/org/whispersystems/bithub/tests/controllers/StatusControllerTest.java
+++ b/src/test/java/org/whispersystems/bithub/tests/controllers/StatusControllerTest.java
@@ -1,0 +1,61 @@
+package org.whispersystems.bithub.tests.controllers;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.fromJson;
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+
+import javax.ws.rs.core.MediaType;
+
+import org.junit.Test;
+import org.whispersystems.bithub.client.CoinbaseClient;
+import org.whispersystems.bithub.controllers.StatusController;
+import org.whispersystems.bithub.entities.RecentTransactionsResponse;
+
+import com.sun.jersey.api.client.ClientResponse;
+import com.yammer.dropwizard.testing.ResourceTest;
+import com.yammer.dropwizard.views.ViewMessageBodyWriter;
+
+public class StatusControllerTest extends ResourceTest {
+
+  private static final BigDecimal PAYOUT_RATE = new BigDecimal(0.02);
+  private static final BigDecimal BALANCE = new BigDecimal(10.01);
+  private static final BigDecimal EXCHANGE_RATE = new BigDecimal(1.0);
+
+  private final CoinbaseClient coinbaseClient = mock(CoinbaseClient.class);
+
+  @Override
+  protected void setUpResources() throws Exception {
+
+    when(coinbaseClient.getRecentTransactions()).thenReturn(fromJson(jsonFixture("payloads/transactions.json"), RecentTransactionsResponse.class).getTransactions());
+    when(coinbaseClient.getAccountBalance()).thenReturn(BALANCE);
+    when(coinbaseClient.getExchangeRate()).thenReturn(EXCHANGE_RATE);
+    addResource(new StatusController(coinbaseClient, PAYOUT_RATE));
+
+    addProvider(ViewMessageBodyWriter.class);
+  }
+
+  @Test
+  public void testTransactionsHtml() throws Exception {
+    ClientResponse response = client().resource("/v1/status/transactions/")
+        .get(ClientResponse.class);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getType()).isEqualTo(MediaType.TEXT_HTML_TYPE);
+    assertThat(response.getEntity(String.class)).contains("<li>Sent $1.10 USD (1.1000 BTC)");
+  }
+
+  @Test
+  public void testTransactionsJson() throws Exception {
+    ClientResponse response = client().resource("/v1/status/transactions/").queryParam("format", "json")
+        .get(ClientResponse.class);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+    assertThat(response.getEntity(String.class)).contains("\"amount\":\"1.10\",\"amountInBTC\":\"1.1000\"");
+  }
+
+}

--- a/src/test/resources/payloads/transactions.json
+++ b/src/test/resources/payloads/transactions.json
@@ -1,0 +1,59 @@
+{
+    "current_user": {
+        "id": "5011f33df8182b142400000e",
+        "email": "user2@example.com",
+        "name": "User Two"
+    },
+    "balance": {
+        "amount": "50.00000000",
+        "currency": "BTC"
+    },
+    "total_count": 2,
+    "num_pages": 1,
+    "current_page": 1,
+    "transactions": [
+        {
+            "transaction": {
+                "id": "5018f833f8182b129c00002f",
+                "created_at": "2012-08-01T02:34:43-07:00",
+                "amount": {
+                    "amount": "-1.10000000",
+                    "currency": "BTC"
+                },
+                "request": true,
+                "status": "pending",
+                "sender": {
+                    "id": "5011f33df8182b142400000e",
+                    "name": "User Two",
+                    "email": "user2@example.com"
+                },
+                "recipient": {
+                    "id": "5011f33df8182b142400000a",
+                    "name": "User One",
+                    "email": "user1@example.com"
+                },
+                "notes": "Commit payment:__moxie0__ https://github.com/WhisperSystems/BitHub/commit/88edf54e5b57c80ac05093a9be90965fd41291c2"
+            }
+        },
+        {
+            "transaction": {
+                "id": "5018f833f8182b129c00002e",
+                "created_at": "2012-08-01T02:36:43-07:00",
+                "hsh": "9d6a7d1112c3db9de5315b421a5153d71413f5f752aff75bf504b77df4e646a3",
+                "amount": {
+                    "amount": "-1.00000000",
+                    "currency": "BTC"
+                },
+                "request": false,
+                "status": "complete",
+                "sender": {
+                    "id": "5011f33df8182b142400000e",
+                    "name": "User Two",
+                    "email": "user2@example.com"
+                },
+                "recipient_address": "37muSN5ZrukVTvyVh3mT5Zc5ew9L9CBare",
+                "notes": "Commit payment:__moxie0__ https://github.com/WhisperSystems/BitHub/commit/88edf54e5b57c80ac05093a9be90965fd41291c2"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Now http://bithub.herokuapp.com/v1/status/transactions/BTC will render the transactions list with payout values in BTC

Addresses Issue #11, as the BTC payout amounts should provide a reference that does not fluctuate with the exchange rate.
