### PR TITLE
Require HTTP basic auth for github webhook

### DIFF
--- a/config/sample.yml
+++ b/config/sample.yml
@@ -3,6 +3,8 @@ github:
   token: # Your BitHub instance's GitHub auth token.
   repositories:
     - # A list of repository URLs to support payouts for.
+  webhook:
+    password: # HTTP basic auth. The username defaults to "bithub".
 
 coinbase:
   apiKey: # Your Coinbase API key.

--- a/src/main/java/org/whispersystems/bithub/BithubServerConfiguration.java
+++ b/src/main/java/org/whispersystems/bithub/BithubServerConfiguration.java
@@ -22,6 +22,7 @@ import com.yammer.dropwizard.config.Configuration;
 import org.whispersystems.bithub.config.BithubConfiguration;
 import org.whispersystems.bithub.config.CoinbaseConfiguration;
 import org.whispersystems.bithub.config.GithubConfiguration;
+import org.whispersystems.bithub.config.WebhookConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;

--- a/src/main/java/org/whispersystems/bithub/BithubService.java
+++ b/src/main/java/org/whispersystems/bithub/BithubService.java
@@ -18,9 +18,11 @@
 package org.whispersystems.bithub;
 
 import com.yammer.dropwizard.Service;
+import com.yammer.dropwizard.auth.basic.BasicAuthProvider;
 import com.yammer.dropwizard.config.Bootstrap;
 import com.yammer.dropwizard.config.Environment;
 import com.yammer.dropwizard.views.ViewBundle;
+import org.whispersystems.bithub.auth.GithubWebhookAuthenticator;
 import org.whispersystems.bithub.client.CoinbaseClient;
 import org.whispersystems.bithub.client.GithubClient;
 import org.whispersystems.bithub.controllers.GithubController;
@@ -51,6 +53,8 @@ public class BithubService extends Service<BithubServerConfiguration> {
   {
     String         githubUser         = config.getGithubConfiguration().getUser();
     String         githubToken        = config.getGithubConfiguration().getToken();
+    String         githubWebhookUser  = config.getGithubConfiguration().getWebhookConfiguration().getUsername();
+    String         githubWebhookPwd   = config.getGithubConfiguration().getWebhookConfiguration().getPassword();
     List<String>   githubRepositories = config.getGithubConfiguration().getRepositories();
     BigDecimal     payoutRate         = config.getBithubConfiguration().getPayoutRate();
     GithubClient   githubClient       = new GithubClient(githubUser, githubToken);
@@ -61,6 +65,8 @@ public class BithubService extends Service<BithubServerConfiguration> {
     environment.addResource(new StatusController(coinbaseClient, payoutRate));
     environment.addProvider(new IOExceptionMapper());
     environment.addProvider(new UnauthorizedHookExceptionMapper());
+    environment.addProvider(new BasicAuthProvider<>(
+      new GithubWebhookAuthenticator(githubWebhookUser, githubWebhookPwd), GithubWebhookAuthenticator.REALM));
   }
 
   public static void main(String[] args) throws Exception {

--- a/src/main/java/org/whispersystems/bithub/auth/GithubWebhookAuthenticator.java
+++ b/src/main/java/org/whispersystems/bithub/auth/GithubWebhookAuthenticator.java
@@ -1,0 +1,34 @@
+package org.whispersystems.bithub.auth;
+
+import com.google.common.base.Optional;
+import com.yammer.dropwizard.auth.Authenticator;
+import com.yammer.dropwizard.auth.basic.BasicCredentials;
+
+/**
+ * Accepts only one fixed username/password combination.
+ */
+public class GithubWebhookAuthenticator implements Authenticator<BasicCredentials, GithubWebhookAuthenticator.Authentication> {
+
+  /**
+   * Represents a successful basic HTTP authentication.
+   */
+  public static class Authentication {
+  }
+
+  public static final String REALM = "bithub";
+
+  private final BasicCredentials correctCredentials;
+
+  public GithubWebhookAuthenticator(String username, String password) {
+    this.correctCredentials = new BasicCredentials(username, password);
+  }
+
+  @Override
+  public Optional<Authentication> authenticate(BasicCredentials clientCredentials) {
+    if (correctCredentials.equals(clientCredentials)) {
+      return Optional.of(new Authentication());
+    } else {
+      return Optional.absent();
+    }
+  }
+}

--- a/src/main/java/org/whispersystems/bithub/config/GithubConfiguration.java
+++ b/src/main/java/org/whispersystems/bithub/config/GithubConfiguration.java
@@ -24,6 +24,8 @@ import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
@@ -45,6 +47,11 @@ public class GithubConfiguration {
 
   @JsonProperty
   private String repositories_heroku;
+
+  @Valid
+  @NotNull
+  @JsonProperty
+  private WebhookConfiguration webhook;
 
   public String getUser() {
     return user;
@@ -69,5 +76,9 @@ public class GithubConfiguration {
     }
 
     return new LinkedList<>();
+  }
+
+  public WebhookConfiguration getWebhookConfiguration() {
+    return webhook;
   }
 }

--- a/src/main/java/org/whispersystems/bithub/config/WebhookConfiguration.java
+++ b/src/main/java/org/whispersystems/bithub/config/WebhookConfiguration.java
@@ -1,0 +1,19 @@
+package org.whispersystems.bithub.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.validator.constraints.NotEmpty;
+
+public class WebhookConfiguration {
+
+  @JsonProperty
+  @NotEmpty
+  private String username = "bithub";
+
+  @JsonProperty
+  @NotEmpty
+  private String password;
+
+  public String getUsername() { return username; }
+
+  public String getPassword() { return password; }
+}

--- a/src/main/java/org/whispersystems/bithub/controllers/GithubController.java
+++ b/src/main/java/org/whispersystems/bithub/controllers/GithubController.java
@@ -18,11 +18,13 @@
 package org.whispersystems.bithub.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yammer.dropwizard.auth.Auth;
 import com.yammer.metrics.annotation.Timed;
 import org.apache.commons.net.util.SubnetUtils;
 import org.apache.commons.net.util.SubnetUtils.SubnetInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.whispersystems.bithub.auth.GithubWebhookAuthenticator.Authentication;
 import org.whispersystems.bithub.client.CoinbaseClient;
 import org.whispersystems.bithub.client.GithubClient;
 import org.whispersystems.bithub.client.TransferFailedException;
@@ -85,8 +87,9 @@ public class GithubController {
   @POST
   @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   @Path("/commits/")
-  public void handleCommits(@HeaderParam("X-Forwarded-For") String clientIp,
-                            @FormParam("payload")           String eventString)
+  public void handleCommits(@Auth Authentication auth,
+                            @HeaderParam("X-Forwarded-For") String clientIp,
+                            @FormParam("payload") String eventString)
       throws IOException, UnauthorizedHookException
   {
     authenticate(clientIp);


### PR DESCRIPTION
Previously, we only checked that X-Forwarded-For (set by Heroku)
contained an IP from a trusted range. However, GitHub recommends
HTTP basic auth:

https://help.github.com/articles/what-ip-addresses-does-github-use-that-i-should-whitelist

Note that if you deploy this, you'll have to update your production.yml and change the Github WebHook URL to include the configured user/password (http(s)://user@password:.../...).
