### PR TITLE
Send rewards directly to Btc, retain Coinbase as fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ Opting Out
 
 If you'd like to opt out of receiving a payment, simply include the string "FREEBIE" somewhere in your commit message, and you will not receive BTC for that commit.
 
+Payment processing
+------------------
+
+By default, you need a coinbase account for recieving payment. However, if you add a `Send-bitcoin-reward: `-line to your commit, you recieve payment to that address instead.
+You may consider adding a git hook that appends this line for you:
+
+    $ git config --global user.reward-btc "your-btc-address"
+    $ cat > .git/hooks/commit-msg << "EOF"
+    #!/bin/sh
+    VAR=$(git config -z user.reward-btc)
+    if [ -n "$VAR" ]; then
+        awk "/Signed-off-by:.*/ && c == 0 {c = 1; print \"Send-bitcoin-reward: $VAR\"}; {print} END{if(c == 0) {print \"Send-bitcoin-reward: $VAR\"}}" $1 > "$1".tmp
+        mv "$1".tmp $1
+    fi
+    EOF
+    $ chmod +x .git/hooks/commit-msg
 
 Building
 -------------

--- a/src/main/java/org/whispersystems/bithub/client/CoinbaseClient.java
+++ b/src/main/java/org/whispersystems/bithub/client/CoinbaseClient.java
@@ -85,7 +85,7 @@ public class CoinbaseClient {
   }
 }
 
-  public void sendPayment(Author author, BigDecimal amount, String url)
+  public void sendPayment(Author author, String overwritingBtcAddress, BigDecimal amount, String url)
       throws TransferFailedException
   {
     try {
@@ -95,7 +95,12 @@ public class CoinbaseClient {
 
       String note = "Commit payment:\n__" + author.getUsername() + "__ " + url;
 
-      BitcoinTransaction transaction = new BitcoinTransaction(author.getEmail(),
+      String recipient = author.getEmail();
+      if (overwritingBtcAddress != null && overwritingBtcAddress != "") {
+        recipient = overwritingBtcAddress;
+      }
+
+      BitcoinTransaction transaction = new BitcoinTransaction(recipient,
                                                               amount.toPlainString(),
                                                               note);
 

--- a/src/test/java/org/whispersystems/bithub/tests/controllers/GithubControllerTest.java
+++ b/src/test/java/org/whispersystems/bithub/tests/controllers/GithubControllerTest.java
@@ -162,6 +162,24 @@ public class GithubControllerTest extends ResourceTest {
         .post(ClientResponse.class, post);
 
     verify(coinbaseClient, never()).sendPayment(any(Author.class),
+                                       anyString(),
+                                       any(BigDecimal.class),
+                                       anyString());
+  }
+
+  @Test
+  public void testCommitSendToLine() throws Exception, TransferFailedException {
+    String payloadValue = payload("/payloads/commit_send_to_line.json");
+    MultivaluedMapImpl post = new MultivaluedMapImpl();
+    post.add("payload", payloadValue);
+    ClientResponse response = client().resource("/v1/github/commits/")
+        .header("X-Forwarded-For", "192.30.252.1")
+        .header("Authorization", authString)
+        .type(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+        .post(ClientResponse.class, post);
+
+    verify(coinbaseClient).sendPayment(any(Author.class),
+                                       eq("1PRmBDjTcgjR13FPMQ3m4fLhTxo3s4tCkg"),
                                        any(BigDecimal.class),
                                        anyString());
   }
@@ -178,6 +196,7 @@ public class GithubControllerTest extends ResourceTest {
         .post(ClientResponse.class, post);
 
     verify(coinbaseClient).sendPayment(any(Author.class),
+                                       anyString(),
                                        eq(BALANCE.multiply(new BigDecimal(0.02))),
                                        anyString());
   }
@@ -194,6 +213,7 @@ public class GithubControllerTest extends ResourceTest {
         .post(ClientResponse.class, post);
 
     verify(coinbaseClient, never()).sendPayment(any(Author.class),
+                                       anyString(),
                                        eq(BALANCE.multiply(new BigDecimal(0.02))),
                                        anyString());
   }
@@ -209,9 +229,9 @@ public class GithubControllerTest extends ResourceTest {
         .type(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
         .post(ClientResponse.class, post);
 
-    verify(coinbaseClient, times(1)).sendPayment(any(Author.class), eq(BALANCE.multiply(new BigDecimal(0.02))),
+    verify(coinbaseClient, times(1)).sendPayment(any(Author.class), anyString(), eq(BALANCE.multiply(new BigDecimal(0.02))),
         anyString());
-    verify(coinbaseClient, times(1)).sendPayment(any(Author.class), eq(BALANCE.subtract(BALANCE.multiply(new BigDecimal(0.02)))
+    verify(coinbaseClient, times(1)).sendPayment(any(Author.class), anyString(), eq(BALANCE.subtract(BALANCE.multiply(new BigDecimal(0.02)))
         .multiply(new BigDecimal(0.02))), anyString());
   }
 
@@ -227,6 +247,7 @@ public class GithubControllerTest extends ResourceTest {
         .post(ClientResponse.class, post);
 
     verify(coinbaseClient).sendPayment(any(Author.class),
+                                       anyString(),
                                        eq(BALANCE.multiply(new BigDecimal(0.02))),
                                        anyString());
   }
@@ -243,6 +264,7 @@ public class GithubControllerTest extends ResourceTest {
         .post(ClientResponse.class, post);
 
     verify(coinbaseClient, never()).sendPayment(any(Author.class),
+                                                anyString(),
                                                 any(BigDecimal.class),
                                                 anyString());
   }

--- a/src/test/resources/payloads/commit_send_to_line.json
+++ b/src/test/resources/payloads/commit_send_to_line.json
@@ -1,0 +1,79 @@
+{
+    "after": "bcf09f8b4a32921114587e4814a3f0849aa9900f",
+    "before": "1b141aa068165dd1ed376f483cd5fdc2c64f32b1",
+    "commits": [
+        {
+            "added": [],
+            "author": {
+                "email": "moxie@thoughtcrime.org",
+                "name": "Moxie Marlinspike",
+                "username": "moxie0"
+            },
+            "committer": {
+                "email": "moxie@thoughtcrime.org",
+                "name": "Moxie Marlinspike",
+                "username": "moxie0"
+            },
+            "distinct": true,
+            "id": "ba1b681c71db4fcd461954b1bf344bc6e29411e5",
+            "message": "Update path\n\nsome-description\nSend-Bitcoin-reward: 1PRmBDjTcgjR13FPMQ3m4fLhTxo3s4tCkg",
+            "modified": [
+                "README.md"
+            ],
+            "removed": [],
+            "timestamp": "2013-12-14T11:42:28-08:00",
+            "url": "https://github.com/moxie0/tempt/commit/ba1b681c71db4fcd461954b1bf344bc6e29411e5"
+        }],
+    "compare": "https://github.com/moxie0/tempt/compare/1b141aa06816...bcf09f8b4a32",
+    "created": false,
+    "deleted": false,
+    "forced": false,
+    "head_commit": {
+        "added": [],
+        "author": {
+            "email": "moxie@thoughtcrime.org",
+            "name": "Moxie Marlinspike",
+            "username": "moxie0"
+        },
+        "committer": {
+            "email": "moxie@thoughtcrime.org",
+            "name": "Moxie Marlinspike",
+            "username": "moxie0"
+        },
+        "distinct": true,
+        "id": "bcf09f8b4a32921114587e4814a3f0849aa9900f",
+        "message": "Merge branch 'master' of github.com:moxie0/tempt",
+        "modified": [],
+        "removed": [],
+        "timestamp": "2013-12-14T11:42:44-08:00",
+        "url": "https://github.com/moxie0/tempt/commit/bcf09f8b4a32921114587e4814a3f0849aa9900f"
+    },
+    "pusher": {
+        "email": "moxie@thoughtcrime.org",
+        "name": "moxie0"
+    },
+    "ref": "refs/heads/master",
+    "repository": {
+        "created_at": 1386866024,
+        "description": "test",
+        "fork": false,
+        "forks": 1,
+        "has_downloads": true,
+        "has_issues": true,
+        "has_wiki": true,
+        "id": 15141344,
+        "master_branch": "master",
+        "name": "tempt",
+        "open_issues": 0,
+        "owner": {
+            "email": "moxie@thoughtcrime.org",
+            "name": "moxie0"
+        },
+        "private": false,
+        "pushed_at": 1387050173,
+        "size": 216,
+        "stargazers": 1,
+        "url": "https://github.com/moxie0/test",
+        "watchers": 1
+    }
+}


### PR DESCRIPTION
Implementing idea from mailing list:
https://lists.riseup.net/www/arc/whispersystems/2013-12/msg00009.html

Commit message:
Users can specify a 'Send-Bitcoin-reward: '-line in the commit message,
containing the address they want to get the payment delivered to. This
will be used as default. In the case the line is not supplied, money is
sent to coinbase e-mail.
