### PR TITLE
Trivially update commit payout image path FREEBIE

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ https://lists.riseup.net/www/info/whispersystems
 
 Current BitHub Payment For Commit: 
 =================
-[![Current Price](https://bithub.herokuapp.com/v1/status/payment/commit)](https://whispersystems.org/blog/bithub/)
+[![Current Price](https://bithub.herokuapp.com/v1/status/payment/commit/)](https://whispersystems.org/blog/bithub/)
 


### PR DESCRIPTION
Bithub is now serving the payout image with Cache-Control: max-age=0 but github/fastly is still serving the old cached image on READMEs for Bithub, TextSecure, etc... Evidently fastly is not re-reading the headers correctly.

This commit simply adds a trailing / to the image path, which changes the url hash and effectively forces fastly to re-fetch the image and its headers. I've confirmed that the README in my fork is no longer caching the image.
