### PR TITLE
Add BTC amounts to transactions list view

### DIFF
--- a/src/main/java/org/whispersystems/bithub/BithubService.java
+++ b/src/main/java/org/whispersystems/bithub/BithubService.java
@@ -62,12 +62,13 @@ public class BithubService extends Application<BithubServerConfiguration> {
     String                        githubWebhookPwd   = config.getGithubConfiguration().getWebhookConfiguration().getPassword();
     List<RepositoryConfiguration> githubRepositories = config.getGithubConfiguration().getRepositories();
     BigDecimal                    payoutRate         = config.getBithubConfiguration().getPayoutRate();
+    int                           btcPrecision       = config.getBithubConfiguration().getBtcPrecision();
     String                        organizationName   = config.getOrganizationConfiguration().getName();
     String                        donationUrl        = config.getOrganizationConfiguration().getDonationUrl().toExternalForm();
 
     GithubClient   githubClient   = new GithubClient(githubUser, githubToken);
     CoinbaseClient coinbaseClient = new CoinbaseClient(config.getCoinbaseConfiguration().getApiKey());
-    CacheManager   cacheManager   = new CacheManager(coinbaseClient, githubClient, githubRepositories, payoutRate);
+    CacheManager   cacheManager   = new CacheManager(coinbaseClient, githubClient, githubRepositories, payoutRate, btcPrecision);
 
     environment.servlets().addFilter("CORS", CrossOriginFilter.class)
                .addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");

--- a/src/main/java/org/whispersystems/bithub/config/BithubConfiguration.java
+++ b/src/main/java/org/whispersystems/bithub/config/BithubConfiguration.java
@@ -30,8 +30,18 @@ public class BithubConfiguration {
   @NotEmpty
   private String payout = "0.02";
 
+  // This is the number of decimal places shown when displaying amounts in BTC
+  // Change this if needed to whatever is appropriate for your payout amounts
+  @JsonProperty
+  @NotEmpty
+  private int btcPrecision = 4;
+
   public BigDecimal getPayoutRate() {
     return new BigDecimal(payout);
+  }
+
+  public int getBtcPrecision() {
+    return btcPrecision;
   }
 
 }

--- a/src/main/java/org/whispersystems/bithub/entities/Transaction.java
+++ b/src/main/java/org/whispersystems/bithub/entities/Transaction.java
@@ -11,6 +11,9 @@ public class Transaction {
   private String amount;
 
   @JsonProperty
+  private String amountInBTC;
+
+  @JsonProperty
   private String commitUrl;
 
   @JsonProperty
@@ -24,11 +27,12 @@ public class Transaction {
 
   public Transaction() {}
 
-  public Transaction(String destination, String amount, String commitUrl,
+  public Transaction(String destination, String amount, String amountInBTC, String commitUrl,
                      String commitSha, String timestamp, String description)
   {
     this.destination = destination;
     this.amount      = amount;
+    this.amountInBTC = amountInBTC;
     this.commitUrl   = commitUrl;
     this.commitSha   = commitSha;
     this.timestamp   = timestamp;
@@ -41,6 +45,10 @@ public class Transaction {
 
   public String getAmount() {
     return amount;
+  }
+
+  public String getAmountInBTC() {
+    return amountInBTC;
   }
 
   public String getCommitUrl() {

--- a/src/main/java/org/whispersystems/bithub/storage/CoinbaseTransactionParser.java
+++ b/src/main/java/org/whispersystems/bithub/storage/CoinbaseTransactionParser.java
@@ -24,6 +24,12 @@ public class CoinbaseTransactionParser {
                                                           .toPlainString();
   }
 
+  public String parseAmountInBTC(int precision) {
+    return new BigDecimal(coinbaseTransaction.getAmount()).abs()
+                                                          .setScale(precision, RoundingMode.CEILING)
+                                                          .toPlainString();
+  }
+
   public String parseTimestamp() throws ParseException {
     String timestamp      = coinbaseTransaction.getCreatedTime();
     int    offendingColon = timestamp.lastIndexOf(':');

--- a/src/main/resources/org/whispersystems/bithub/views/recent_transactions.mustache
+++ b/src/main/resources/org/whispersystems/bithub/views/recent_transactions.mustache
@@ -44,7 +44,7 @@
 
 <ul>
     {{#transactions}}
-    <li>Sent ${{amount}} USD to <a href="https://github.com/{{destination}}" target="_blank">{{destination}}</a> for <a href="{{commitUrl}}" target="_blank"><sha>{{commitSha}}</sha></a> {{timestamp}}.</li>
+        <li>Sent ${{amount}} USD to <a href="https://github.com/{{destination}}" target="_blank">{{destination}}</a> for <a href="{{commitUrl}}" target="_blank"><sha>{{commitSha}}</sha></a> {{timestamp}}.</li>
     {{/transactions}}
 </ul>
 

--- a/src/test/java/org/whispersystems/bithub/tests/controllers/StatusControllerTest.java
+++ b/src/test/java/org/whispersystems/bithub/tests/controllers/StatusControllerTest.java
@@ -28,6 +28,7 @@ public class StatusControllerTest {
   private static final BigDecimal PAYOUT_RATE   = new BigDecimal(0.02 );
   private static final BigDecimal BALANCE       = new BigDecimal(10.01);
   private static final BigDecimal EXCHANGE_RATE = new BigDecimal(1.0  );
+  private static final int        BTC_PRECISION = 4;
 
   private static final CoinbaseClient coinbaseClient = mock(CoinbaseClient.class);
   private static final GithubClient   githubClient   = mock(GithubClient.class  );
@@ -43,7 +44,8 @@ public class StatusControllerTest {
 
       CacheManager coinbaseManager = new CacheManager(coinbaseClient, githubClient,
                                                       new LinkedList<RepositoryConfiguration>(),
-                                                      PAYOUT_RATE);
+                                                      PAYOUT_RATE,
+                                                      BTC_PRECISION);
       coinbaseManager.start();
 
       resources = ResourceTestRule.builder()
@@ -69,6 +71,7 @@ public class StatusControllerTest {
 //
 //    assertThat(response.getStatus()).isEqualTo(200);
 //    assertThat(response.getType()).isEqualTo(MediaType.TEXT_HTML_TYPE);
+//    assertThat(response.getEntity(String.class)).contains("<li>Sent $1.10 USD (1.1000 BTC)");
 //  }
 
   @Test
@@ -78,6 +81,7 @@ public class StatusControllerTest {
 
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+    assertThat(response.getEntity(String.class)).contains("\"amount\":\"1.10\",\"amountInBTC\":\"1.1000\"");
   }
 
 }


### PR DESCRIPTION
Supersedes PR #15.

Adds BTC transaction amounts to Transaction objects, so that in the transactions list view one will see entries like: 
`Sent $X USD (Y BTC) to {{destination}} for {{commit}`

The BTC amounts are also included in the Transaction JSON object.

Also includes unit tests for BTC amounts.

Addresses Issue #11
