### PR TITLE
link to actual install instead of blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,6 @@ https://lists.riseup.net/www/info/whispersystems
 
 Current BitHub Payment For Commit: 
 =================
-[![Current Price](https://bithub.herokuapp.com/v1/status/payment/commit)](https://whispersystems.org/blog/bithub/)
+
+[![Current Price](https://bithub.herokuapp.com/v1/status/payment/commit)](https://bithub.herokuapp.com/)
 


### PR DESCRIPTION
i had all the trouble in the world finding an actual instance of the service running somewhere. only through #19 did i realize there was actually a page listing the projects, how to donate an so on: https://bithub.herokuapp.com.

link to it instead of the website, which is linked earlier.
