### PR TITLE
Fix links from dashboard to repos

### DIFF
--- a/src/main/java/org/whispersystems/bithub/entities/Repository.java
+++ b/src/main/java/org/whispersystems/bithub/entities/Repository.java
@@ -31,6 +31,10 @@ public class Repository {
   private String url;
 
   @JsonProperty
+  @NotEmpty
+  private String html_url;
+
+  @JsonProperty
   @NotNull
   private Author owner;
 
@@ -57,6 +61,10 @@ public class Repository {
 
   public String getUrl() {
     return url;
+  }
+
+  public String getHtmlUrl() {
+    return html_url;
   }
 
   public String getDescription() {

--- a/src/main/resources/org/whispersystems/bithub/views/dashboard.mustache
+++ b/src/main/resources/org/whispersystems/bithub/views/dashboard.mustache
@@ -146,7 +146,7 @@
             <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
                 <div class="repository">
                     <div class="repository-name">
-                        <a href="{{url}}">{{name}}</a>
+                        <a href="{{htmlUrl}}">{{name}}</a>
                     </div>
                     <div class="repository-description">
                         <p>{{description}}</p>


### PR DESCRIPTION
They were previously linking to the github api payload for each repo.

This bug is visible in production right now at http://bithub.whispersystems.org/